### PR TITLE
Drop py2.7 from travis, include required packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
+dist: xenial
+addons:
+  apt:
+    packages:
+      - docker
 language: python
 python:
   - '3.6'
+  - '3.7'
 stages:
 - linting
 - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ jobs:
       - pre-commit run --all-files
 install:
   - pip install -U setuptools pip
-  - pip install -U -e . pytest docker
+  - pip install -U -e . pytest docker requests
 script:
-- pytest
+  - pytest
 cache:
   directories:
-    - $HOME/.cache/pip
+    #- $HOME/.cache/pip
     - $HOME/.cache/pre-commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 addons:
   apt:
     packages:
-      - docker
+      - docker-ce
 services:
   - docker
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ addons:
   apt:
     packages:
       - docker
+services:
+  - docker
 language: python
 python:
   - '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ install:
   - pip install -U setuptools pip
   - pip install -U -e . pytest docker requests
   - docker pull cfmeqe/webdriver-wharf
+  - docker pull cfmeqe/cfme_sel_stable
   - |
       docker run \
         --detach \

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ install:
         --volume /var/run/docker.sock:/var/run/docker.sock:rw \
         cfmeqe/webdriver-wharf
   - docker ps
+  - sleep 10
+  - docker logs webdriver-wharf-kaifuku-test
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
 install:
   - pip install -U setuptools pip
   - pip install -U -e . pytest docker requests
+  - docker pull cfmeqe/webdriver-wharf
 script:
   - pytest
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - '2.7'
   - '3.6'
 stages:
 - linting
@@ -33,7 +32,7 @@ jobs:
       - pre-commit run --all-files
 install:
   - pip install -U setuptools pip
-  - pip install -U -e . pytest
+  - pip install -U -e . pytest docker
 script:
 - pytest
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,18 @@ install:
   - pip install -U setuptools pip
   - pip install -U -e . pytest docker requests
   - docker pull cfmeqe/webdriver-wharf
+  - |
+      docker run \
+        --detach \
+        --name webdriver-wharf-kaifuku-test \
+        --rm \
+        --privileged \
+        --network host \
+        --volume /var/run/docker.sock:/var/run/docker.sock:rw \
+        cfmeqe/webdriver-wharf
+  - docker ps
+
+
 script:
   - pytest
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
         --name webdriver-wharf-kaifuku-test \
         --rm \
         --privileged \
-        --network host \
+        --publish-all \
         --volume /var/run/docker.sock:/var/run/docker.sock:rw \
         cfmeqe/webdriver-wharf
   - docker ps

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@ name = webdriver_kaifuku
 
 license_file = LICENSE
 
-[bdist_wheel]
-universal = true
-
 [options]
 packages = find:
 install_requires=

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ packages = find:
 install_requires=
   attrs>=18.0
   wait_for
+  selenium
 
 [options.packages.find]
 where = src

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from wait_for import wait_for
 
 WHARF_URL = "http://localhost:4899"
-WHARF_IMAGE = "cfmeqe/webdriver-wharf"
+WHARF_IMAGE = "docker.io/cfmeqe/webdriver-wharf"
 BROWSER_IMAGE = "cfmeqe/cfme_sel_stable"
 
 
@@ -19,7 +19,7 @@ def crate_or_reuse_existing(name, image, **kw):
         # assume similar setup
         container = client.containers.get(name)
         existed = True
-    except docker.errors.NotFound:
+    except (docker.errors.NotFound, docker.errors.ImageNotFound):
         container = client.containers.run(name=name, image=image, **kw)
         existed = False
     else:
@@ -37,7 +37,7 @@ def wharf_setup():
 
     with crate_or_reuse_existing(
         name="webdriver-wharf-kaifuku-test",
-        image="cfmeqe/webdriver-wharf",
+        image=WHARF_IMAGE,
         auto_remove=True,
         detach=True,
         privileged=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py2,py3
+envlist=py36,py37
 
 [testenv]
 deps=
@@ -7,6 +7,7 @@ deps=
 	selenium
 	docker
 	wait_for
+	requests
 commands = pytest {posargs:testing}
 
 [flake8]


### PR DESCRIPTION
wait_for is no longer py2.7 compatible
selenium is required by wharf module
docker is required by conftest (installed in travis directly)