### PR TITLE
Fix test tox env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# custom
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - '2.7'
   - '3.6'
+  - '3.7'
+  - '3.8'
 stages:
 - linting
 - test

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@ universal = true
 packages = find:
 install_requires=
   attrs>=18.0
-  wait_for
+  requests
+  selenium
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist=py2,py3
+envlist=py{36,37,38},pypy3
 
 [testenv]
 deps=
 	pytest
-	selenium
 	docker
 	wait_for
 commands = pytest {posargs:testing}


### PR DESCRIPTION
Before moving to github action trying to fix test run env.

- Container name changes
- Wharf created child containers to clean added one fixture
- removed `wait_for` as package dependency and moved to tox as its test env dependency. 
- Added `selenium` and `requests` as package dependency

