### PR TITLE
Fix Firefox proxy setup

### DIFF
--- a/src/webdriver_kaifuku/__init__.py
+++ b/src/webdriver_kaifuku/__init__.py
@@ -144,7 +144,7 @@ class BrowserManager:
             opts.set_capability(
                 "proxy",
                 {
-                    "proxyType": "MANUAL",
+                    "proxyType": "manual",
                     "httpProxy": browser_conf["proxy_url"],
                     "sslProxy": browser_conf["proxy_url"],
                 },


### PR DESCRIPTION
This is going to fix the issue with Firefox session creation 
```
13:12:51.183 WARN [SeleniumSpanExporter$1.lambda$export$1] - Unable to create session: Could not start a new session. Error while creating session with the driver service. Stopping driver service: Could not start a new session. Response code 400. Message: Invalid proxyType value: MANUAL
```

Tested locally with official selenium, works great